### PR TITLE
Declare github_user variable in main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,10 @@ variable "tailscale_auth_key" {
   sensitive = true
 }
 
+variable "github_user" {
+  type = string
+}
+
 resource "oci_core_instance" "oracle-arm" {
   display_name   = "oracle-arm"
   compartment_id = var.oci_compartment_id


### PR DESCRIPTION
Plan was failing as github_user variable wasn't defined. Super useful project, thanks for sharing !

```
Error: Reference to undeclared input variable

  on main.tf line 47, in resource "oci_core_instance" "oracle-arm":
  47:           github_user = var.github_user,

An input variable with the name "github_user" has not been declared. This variable can be declared with a variable "github_user" {} block.
```